### PR TITLE
compare password functionality

### DIFF
--- a/src/user/auth.rs
+++ b/src/user/auth.rs
@@ -7,6 +7,7 @@ use rocket::Request;
 use rocket::State;
 use serde_json::json;
 use std::time::Duration;
+use argon2::verify_encoded;
 
 /// The [`Auth`] guard allows to log in, log out, sign up, modify, and delete the currently (un)authenticated user.
 /// For more information see [`Auth`].
@@ -302,5 +303,20 @@ impl<'a> Auth<'a> {
     pub fn get_session(&self) -> &Session {
         let session = self.session.as_ref().ok_or(Error::UnauthenticatedError)?;
         session
+    }
+
+    /// Compares the password of the currently authenticated user with a new password.
+    /// Useful for checking password before resetting email/password.
+    /// To avoid bruteforcing this function should not be directly accessible from a route.
+    /// Additionally, it is good to implement rate limiting on routes using this function.
+    #[throws(Error)]
+    pub async fn compare_password(&self, new_password: &str) -> bool {
+        if self.is_auth().await {
+            let session = self.get_session()?;
+            let mut user: User = self.users.get_by_id(session.id).await?;
+            verify_encoded(&user.password, new_password.as_bytes())?
+        } else {
+            throw!(Error::UnauthorizedError)
+        }
     }
 }

--- a/src/user/user_impl.rs
+++ b/src/user/user_impl.rs
@@ -33,6 +33,15 @@ impl User {
         self.password = hash;
     }
 
+    /// Compares the password of the currently authenticated user with a new password.
+    /// Useful for checking password before resetting email/password.
+    /// To avoid bruteforcing this function should not be directly accessible from a route.
+    /// Additionally, it is good to implement rate limiting on routes using this function.
+    #[throws(Error)]
+    pub async fn compare_password(&self, new_password: &str) -> bool {
+        verify_encoded(&self.password, new_password.as_bytes())?
+    }
+
     /// This is an accessor function for the private `id` field.
     /// This field is private so it is not modified by accident when updating a user.
     /// ```rust
@@ -136,6 +145,8 @@ impl<'r> FromRequest<'r> for AdminUser {
 }
 
 use std::ops::*;
+use argon2::verify_encoded;
+
 impl Deref for AdminUser {
     type Target = User;
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
I have now implemented a method called compare_password(). It is located both in the Auth and User guard. I implemented it in both, so that you can decide where it is more useful. I myself think it is better to have it in the User guard, because that makes sure that a logged in user exists, but that is up to you to decide. The function was also tested in one of my projects, where i temporary used my fork of rocket_auth as a dependencie. The documentation and function name is just an idea, feel free to change it :)

If you think it should be implemented otherwise, write a comment i will fix it