### PR TITLE
Derestrict rusqlite dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ sqlx-mysql = ["sqlx/mysql"]
 
 
 [dependencies.rusqlite]
-version = "0.25.3"
+version = ">=0.25.3"
 optional = true
 
 


### PR DESCRIPTION
This commit removes depending _exactly_ on rusqlite 0.25.3 (which has been [yanked](https://crates.io/crates/rusqlite/0.25.3) btw).

From quick testing, depending on the latest version (0.27.0) works too, so alternatively, you could change the version to be `0.27.0` rather than this commit's suggestion.

As an alternative, running `cargo upgrade` to update _all_ dependencies to latest versions, it seems like everything builds fine (and the tests seem to produce some minor fixable suggestions), so maybe if making a new release, it might be good to update all dependencies. Happy to make a separate PR if you think it would be useful.

Thanks for this project btw! :)