### PR TITLE
Fixed postgres database 'UPDATE_USER' string in sql.rs

### DIFF
--- a/src/db/postgres/sql.rs
+++ b/src/db/postgres/sql.rs
@@ -12,10 +12,10 @@ INSERT INTO users (email, password, is_admin) VALUES ($1, $2, $3);
 ";
 
 pub(crate) const UPDATE_USER: &str = "
-UPDATE table SET 
+UPDATE users SET
     email = $2,
     password = $3,
-    is_admin = $4,
+    is_admin = $4
 WHERE
     id = $1
 ";


### PR DESCRIPTION
This is the same issue as with #47 and #45. This issue probably also exists for the other database implementations, as the have the same pattern. I did not change it for those, because i don't have them installed and can't test it. If you want i can change those as well.