### PR TITLE
Update Rocket, sqlx, and rusqlite dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ sqlx-mysql = ["sqlx/mysql"]
 
 
 [dependencies.rusqlite]
-version = "0.27.0"
+version = "0.30.0"
 optional = true
 
 
@@ -44,12 +44,12 @@ futures= "0.3.21"
 
 
 [dependencies.sqlx]
-version = "0.6.0"
+version = "0.7.4"
 optional = true
 
 
 [dependencies.rocket]
-version = "0.5.0-rc.2"
+version = "0.5.0"
 features = ["secrets"]
 
 [dependencies.serde]
@@ -75,7 +75,7 @@ tokio-postgres= "0.7.6"
 
 
 [dev-dependencies.rocket]
-version = "0.5.0-rc.2"
+version = "0.5.0"
 features = ["secrets", "json"]
 
 [dev-dependencies.redis]
@@ -84,12 +84,12 @@ features = ["aio", "tokio-comp"]
 
 
 [dev-dependencies.rocket_dyn_templates]
-version = "0.1.0-rc.2"
+version = "0.1.0"
 features = ["tera"]
 
 
 [dev-dependencies.sqlx]
-version = "0.6.0"
+version = "0.7.4"
 features = ["runtime-tokio-rustls"]
 
 [dev-dependencies.rocket_auth]

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -24,7 +24,6 @@ pub struct Session {
     pub auth_key: String,
 }
 
-
 #[async_trait]
 impl<'r> FromRequest<'r> for Session {
     type Error = Error;
@@ -34,7 +33,7 @@ impl<'r> FromRequest<'r> for Session {
         if let Some(session) = get_session(cookies) {
             Outcome::Success(session)
         } else {
-            Outcome::Failure((Status::Unauthorized, Error::UnauthorizedError))
+            Outcome::Error((Status::Unauthorized, Error::UnauthorizedError))
         }
     }
 }

--- a/src/user/auth.rs
+++ b/src/user/auth.rs
@@ -64,7 +64,7 @@ impl<'r> FromRequest<'r> for Auth<'r> {
         let users: &State<Users> = if let Outcome::Success(users) = req.guard().await {
             users
         } else {
-            return Outcome::Failure((Status::InternalServerError, Error::UnmanagedStateError));
+            return Outcome::Error((Status::InternalServerError, Error::UnmanagedStateError));
         };
 
         Outcome::Success(Auth {
@@ -222,7 +222,7 @@ impl<'a> Auth<'a> {
     pub fn logout(&self) {
         let session = self.get_session()?;
         self.users.logout(session)?;
-        self.cookies.remove_private(Cookie::named("rocket_auth"));
+        self.cookies.remove_private(Cookie::from("rocket_auth"));
     }
     /// Deletes the account of the currently authenticated user.
     /// ```rust
@@ -238,7 +238,7 @@ impl<'a> Auth<'a> {
         if self.is_auth() {
             let session = self.get_session()?;
             self.users.delete(session.id).await?;
-            self.cookies.remove_private(Cookie::named("rocket_auth"));
+            self.cookies.remove_private(Cookie::from("rocket_auth"));
         } else {
             throw!(Error::UnauthenticatedError)
         }
@@ -308,7 +308,7 @@ impl<'a> Auth<'a> {
     #[throws(Error)]
     pub async fn compare_password(&self, password: &str) -> bool {
         if self.is_auth() {
-            let session = self.get_session()?; 
+            let session = self.get_session()?;
             let user: User = self.users.get_by_id(session.id).await?;
             user.compare_password(password)?
         } else {

--- a/src/user/user_impl.rs
+++ b/src/user/user_impl.rs
@@ -12,7 +12,7 @@ impl User {
     /// In case the user is authenticated,
     /// you can change it more easily with [`change_password`](`super::auth::Auth::change_password`).
     /// This function will fail in case the password is not secure enough.
-    /// 
+    ///
     /// ```rust
     /// # use rocket::{State, post};
     /// # use rocket_auth::{Error, Users};
@@ -113,13 +113,13 @@ impl<'r> FromRequest<'r> for User {
         let guard = request.guard().await;
         let auth: Auth = match guard {
             Success(auth) => auth,
-            Failure(x) => return Failure(x),
+            Error(x) => return Error(x),
             Forward(x) => return Forward(x),
         };
         if let Some(user) = auth.get_user().await {
             Outcome::Success(user)
         } else {
-            Outcome::Failure((Status::Unauthorized, Error::UnauthorizedError))
+            Outcome::Error((Status::Unauthorized, crate::Error::UnauthorizedError))
         }
     }
 }
@@ -132,7 +132,7 @@ impl<'r> FromRequest<'r> for AdminUser {
         let guard = request.guard().await;
         let auth: Auth = match guard {
             Success(auth) => auth,
-            Failure(x) => return Failure(x),
+            Error(x) => return Error(x),
             Forward(x) => return Forward(x),
         };
         if let Some(user) = auth.get_user().await {
@@ -140,12 +140,12 @@ impl<'r> FromRequest<'r> for AdminUser {
                 return Outcome::Success(AdminUser(user));
             }
         }
-        Outcome::Failure((Status::Unauthorized, Error::UnauthorizedError))
+        Outcome::Error((Status::Unauthorized, crate::Error::UnauthorizedError))
     }
 }
 
-use std::ops::*;
 use argon2::verify_encoded;
+use std::ops::*;
 
 impl Deref for AdminUser {
     type Target = User;


### PR DESCRIPTION
I wanted to use rocket_auth with my project, but couldn't compile due to a dependency conflict with libsqlite3-sys that's used by a more recent sqlx version. This is my attempt to update rocket, sqlx, and rusqlite dependencies to enable building with my project. The main code changes are to switch off of deprecated or removed Rocket APIs (i.e. `Outcome::Failure` -> `Outcome::Error` and `Cookie::named` -> `Cookie::from`).

I am still integrating with my project to fully test, but please let me know if I should test/change something else to make this PR acceptable.